### PR TITLE
feat: Allow users to supply additional syntax extensions

### DIFF
--- a/Sources/Parsley/Parsley.swift
+++ b/Sources/Parsley/Parsley.swift
@@ -7,15 +7,19 @@ public enum MarkdownError: Error {
 
 public struct Parsley {
   /// This parses a String into HTML, without parsing Metadata or the document title.
-  public static func html(_ content: String, options: MarkdownOptions = [.safe], additionalExtensions: [UnsafeMutablePointer<cmark_syntax_extension>] = []) throws -> String {
+  public static func html(
+    _ content: String,
+    options: MarkdownOptions = [.safe],
+    additionalSyntaxExtensions: [UnsafeMutablePointer<cmark_syntax_extension>] = []
+  ) throws -> String {
     // Create parser
     guard let parser = cmark_parser_new(options.rawValue) else {
       throw MarkdownError.conversionFailed
     }
 
     // Register user-defined extensions
-    for additionalExtension in additionalExtensions {
-      cmark_parser_attach_syntax_extension(parser, additionalExtension)
+    for syntaxExtension in additionalSyntaxExtensions {
+      cmark_parser_attach_syntax_extension(parser, syntaxExtension)
     }
     
     // Register default extensions
@@ -58,11 +62,19 @@ public struct Parsley {
   }
 
   /// This parses a String into a Document, which contains parsed Metadata and the document title.
-  public static func parse(_ content: String, options: MarkdownOptions = [.safe]) throws -> Document {
+  public static func parse(
+    _ content: String,
+    options: MarkdownOptions = [.safe],
+    additionalSyntaxExtensions: [UnsafeMutablePointer<cmark_syntax_extension>] = []
+  ) throws -> Document {
     let (header, title, rawBody) = Parsley.parts(from: content)
 
     let metadata = Parsley.metadata(from: header)
-    let bodyHtml = try Parsley.html(rawBody, options: options).trimmingCharacters(in: .newlines)
+    let bodyHtml = try Parsley.html(
+      rawBody,
+      options: options,
+      additionalSyntaxExtensions: additionalSyntaxExtensions
+    ).trimmingCharacters(in: .newlines)
 
     return Document(title: title, rawBody: rawBody, body: bodyHtml, metadata: metadata)
   }

--- a/Sources/Parsley/Parsley.swift
+++ b/Sources/Parsley/Parsley.swift
@@ -7,13 +7,18 @@ public enum MarkdownError: Error {
 
 public struct Parsley {
   /// This parses a String into HTML, without parsing Metadata or the document title.
-  public static func html(_ content: String, options: MarkdownOptions = [.safe]) throws -> String {
+  public static func html(_ content: String, options: MarkdownOptions = [.safe], additionalExtensions: [UnsafeMutablePointer<cmark_syntax_extension>] = []) throws -> String {
     // Create parser
     guard let parser = cmark_parser_new(options.rawValue) else {
       throw MarkdownError.conversionFailed
     }
+
+    // Register user-defined extensions
+    for additionalExtension in additionalExtensions {
+      cmark_parser_attach_syntax_extension(parser, additionalExtension)
+    }
     
-    // Register extensions
+    // Register default extensions
     cmark_parser_attach_syntax_extension(parser, create_autolink_extension())
     cmark_parser_attach_syntax_extension(parser, create_strikethrough_extension())
     cmark_parser_attach_syntax_extension(parser, create_table_extension())

--- a/Sources/Parsley/SyntaxExtension.swift
+++ b/Sources/Parsley/SyntaxExtension.swift
@@ -1,0 +1,47 @@
+import CMarkGFM
+
+/// An unsafe pointer to a syntax extension. Can only be used with one parser.
+public typealias SyntaxExtensionPointer = UnsafeMutablePointer<cmark_syntax_extension>
+/// A function that can create instances of a syntax extension.
+public typealias SyntaxExtensionInitializer = () -> SyntaxExtensionPointer
+
+/// A cmark-gfm syntax extension.
+public enum SyntaxExtension {
+  /// Automatically turns plaintext URLs into links
+  case autolink
+  /// Adds the `~text~` syntax for adding the strikethrough style to text.
+  case strikethrough
+  /// Enables the creation of tables.
+  case table
+  /// Filters out the following HTML tags: `["title", "textarea", "style", "xmp", "iframe", "noembed", "noframes", "script", "plaintext"]`.
+  case tagfilter
+  /// Adds the `- [ ] This is a task` syntax for creating tasklists.
+  case tasklist
+  /// A custom syntax extension (currently it is easiest to make these in C and import them into Swift).
+  case custom(SyntaxExtensionInitializer)
+
+  /// The extensions enabled by default (all built-in GFM extensions).
+  public static var defaultExtensions: [SyntaxExtension] {
+    [.autolink, .strikethrough, .table, .tagfilter, .tasklist]
+  }
+
+  /// Creates a pointer to an instance of the syntax extension.
+  ///
+  /// This pointer can only be used for a single parser because it gets freed along with the parser.
+  func createPointer() -> SyntaxExtensionPointer {
+    switch self {
+      case .autolink:
+        return create_autolink_extension()
+      case .strikethrough:
+        return create_strikethrough_extension()
+      case .table:
+        return create_table_extension()
+      case .tagfilter:
+        return create_tagfilter_extension()
+      case .tasklist:
+        return create_tasklist_extension()
+      case .custom(let syntaxExtensionInitializer):
+        return syntaxExtensionInitializer()
+    }
+  }
+}


### PR DESCRIPTION
Hi again @kevinrenskers,

I have started using Parsley in one of my projects and I need to be able to load a custom cmark-gfm syntax extension. To allow this, I have simply added an `additionalSyntaxExtensions` parameter to `Parsley.html` and `Parsley.parse` to keep the changes as minimal as possible. This introduces no breaking changes. If you would rather for syntax extensions be specified in some other way, I'd be happy to change the implementation.

Cheers,
stackotter